### PR TITLE
Update ethereum dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "ethash"
 description = "An Apache-licensed Ethash implementation."
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Wei Tang <hi@that.world>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-ethereum-types = { version = "0.8", default-features = false }
-primitive-types = { version = "0.6", default-features = false, features = ["rlp"] }
-rlp = { version = "0.4", default-features = false }
+ethereum-types = { version = "0.10.0", default-features = false }
+primitive-types = { version = "0.8", default-features = false, features = ["rlp"] }
+rlp = { version = "0.5", default-features = false }
 byteorder = { version = "1", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ use ethereum_types::{U256, H256, H64, H512, U64, BigEndianHash};
 use byteorder::{LittleEndian, ByteOrder};
 use rlp::Encodable;
 use core::ops::BitXor;
-use alloc::vec::Vec;
 
 pub const DATASET_BYTES_INIT: usize = 1073741824; // 2 to the power of 30.
 pub const DATASET_BYTES_GROWTH: usize = 8388608; // 2 to the power of 23.


### PR DESCRIPTION
Substrate has upgraded its dependency for `primitive-types` to v0.8, so we need to follow suit in order to fix errors like this:

```
error[E0308]: mismatched types
   --> primitives/ethereum/src/ethashproof.rs:190:13
    |
190 |             header_hash,
    |             ^^^^^^^^^^^ expected struct `sp_runtime::testing::H256`, found struct `ethereum_types::H256`

```